### PR TITLE
Greenkeeper/grunt noflo browser 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "grunt-noflo-browser": "^1.3.0",
     "json-loader": "^0.5.4",
     "mocha": "^3.2.0",
-    "noflo-runtime-iframe": "^0.8.0",
-    "noflo-runtime-webrtc": "^0.8.0"
+    "noflo-runtime-postmessage": "^0.8.2"
   },
   "keywords": [
     "noflo"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-gh-pages": "^2.0.0",
     "grunt-mocha-phantomjs": "^4.0.0",
     "grunt-mocha-test": "^0.13.2",
-    "grunt-noflo-browser": "^1.1.2",
+    "grunt-noflo-browser": "^1.3.0",
     "json-loader": "^0.5.4",
     "mocha": "^3.2.0",
     "noflo-runtime-iframe": "^0.8.0",


### PR DESCRIPTION
Fixes #48 and switches from iframe and webrtc transports to postMessage